### PR TITLE
update readme with validate root password in mysql

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ docker run --name=sonoLightReservation \
 docker exec -it sonoLightReservation /bin/bash
 #Ouvrir le shell mysql
 mysql -h 172.17.0.2 -uroot -p --port 3306
+#Reset le mot de passe root de la DB (sinon onetime_password par defaut)
+ALTER USER 'root'@'localhost' IDENTIFIED BY 'root';
 #Creation de la base de données
 create database sonoLightReservation;
 #Sortir de la database + du container

--- a/code/back-java/Readme.md
+++ b/code/back-java/Readme.md
@@ -23,6 +23,8 @@ docker run --name=sonoLightReservation \
 docker exec -it sonoLightReservation /bin/bash
 #Ouvrir le shell mysql
 mysql -h 172.17.0.2 -uroot -p --port 3306
+#Reset le mot de passe root de la DB (sinon onetime_password par defaut)
+ALTER USER 'root'@'localhost' IDENTIFIED BY 'root';
 #Creation de la base de données
 create database sonoLightReservation;
 #Sortir de la database + du container


### PR DESCRIPTION
Quand on rentre dans le container puis dans mysql : 

 When asked, enter the generated root password (see the last step in Starting a MySQL Server Instance above on how to find the password). Because the MYSQL_ONETIME_PASSWORD option is true by default, after you have connected a mysql client to the server, you must reset the server root password by issuing this statement:

mysql> ALTER USER 'root'@'localhost' IDENTIFIED BY 'password';